### PR TITLE
Update README.md to use connect URL to add a layer to a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,8 @@ Select your `lambda.zip` as the "Function code" and make the handler "index.hand
 
 ![Function code](https://raw.githubusercontent.com/lambci/node-custom-lambda/master/img/function_code.png "Function code setup screenshot")
 
-Then click on Layers and choose "Add a layer", and "Provide a layer version
-ARN" and enter the following ARN:
 
-```
-arn:aws:lambda:us-east-1:553035198032:layer:nodejs10:1
-```
+Then click [arn:aws:lambda:us-east-1:553035198032:layer:nodejs10:1](https://console.aws.amazon.com/lambda/home?region=us-east-1#/connect/layer?layer=arn:aws:lambda:us-east-1:553035198032:layer:nodejs10:1) and pick your function from the "Function name" auto-suggest.
 
 ![Add a layer](https://raw.githubusercontent.com/lambci/node-custom-lambda/master/img/layer.png "Add a layer screenshot")
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,13 @@ Select your `lambda.zip` as the "Function code" and make the handler "index.hand
 
 ![Function code](https://raw.githubusercontent.com/lambci/node-custom-lambda/master/img/function_code.png "Function code setup screenshot")
 
+Then click on Layers and choose "Add a layer", and "Provide a layer version ARN" and enter the following ARN:
 
-Then click [arn:aws:lambda:us-east-1:553035198032:layer:nodejs10:1](https://console.aws.amazon.com/lambda/home?region=us-east-1#/connect/layer?layer=arn:aws:lambda:us-east-1:553035198032:layer:nodejs10:1) and pick your function from the "Function name" auto-suggest.
+```
+arn:aws:lambda:us-east-1:553035198032:layer:nodejs10:1
+```
+
+Or [use this link](https://console.aws.amazon.com/lambda/home?region=us-east-1#/connect/layer?layer=arn:aws:lambda:us-east-1:553035198032:layer:nodejs10:1) and pick your function from the "Function name" auto-suggest.
 
 ![Add a layer](https://raw.githubusercontent.com/lambci/node-custom-lambda/master/img/layer.png "Add a layer screenshot")
 


### PR DESCRIPTION
Hi, 

I'm making this pull request to propose to use AWS Lambda Console connect URL to associate a layer ARN to a function. 

Basically, you can go to `<AWS Lambda Console Home>#/connect/layer?layer=arn:aws:lambda:us-east-1:553035198032:layer:nodejs10:1` to land on the "Add layer to function" page with the ARN pasted in the "Provide a layer version ARN" input box.

Then you could pick any function you want to add that layer. Please see the screenshot for the result.

<img width="1248" alt="add layer to a function" src="https://user-images.githubusercontent.com/7760864/49671609-5614cf00-fa1d-11e8-8cb6-d9adeba738ba.png">


Thanks.