### PR TITLE
Make sure NODE_PATH is set

### DIFF
--- a/v10.x/bootstrap
+++ b/v10.x/bootstrap
@@ -1,6 +1,7 @@
 #!/bin/dash -e
 
-NODE_PATH="/opt/nodejs/node8/node_modules/:/opt/nodejs/node_modules:$LAMBDA_RUNTIME_DIR/node_modules" \
+export NODE_PATH=/opt/nodejs/node10/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules:/var/runtime:/var/task
+
 /opt/bin/node \
   --expose-gc \
   --max-semi-space-size=$((AWS_LAMBDA_FUNCTION_MEMORY_SIZE * 5 / 100)) \

--- a/v10.x/bootstrap
+++ b/v10.x/bootstrap
@@ -1,5 +1,6 @@
 #!/bin/dash -e
 
+NODE_PATH="/opt/nodejs/node8/node_modules/:/opt/nodejs/node_modules:$LAMBDA_RUNTIME_DIR/node_modules" \
 /opt/bin/node \
   --expose-gc \
   --max-semi-space-size=$((AWS_LAMBDA_FUNCTION_MEMORY_SIZE * 5 / 100)) \

--- a/v11.x/bootstrap
+++ b/v11.x/bootstrap
@@ -1,5 +1,6 @@
 #!/bin/dash -e
 
+NODE_PATH="/opt/nodejs/node8/node_modules/:/opt/nodejs/node_modules:$LAMBDA_RUNTIME_DIR/node_modules" \
 /opt/bin/node \
   --expose-gc \
   --max-semi-space-size=$((AWS_LAMBDA_FUNCTION_MEMORY_SIZE * 5 / 100)) \

--- a/v11.x/bootstrap
+++ b/v11.x/bootstrap
@@ -1,6 +1,7 @@
 #!/bin/dash -e
 
-NODE_PATH="/opt/nodejs/node8/node_modules/:/opt/nodejs/node_modules:$LAMBDA_RUNTIME_DIR/node_modules" \
+export NODE_PATH=/opt/nodejs/node11/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules:/var/runtime:/var/task
+
 /opt/bin/node \
   --expose-gc \
   --max-semi-space-size=$((AWS_LAMBDA_FUNCTION_MEMORY_SIZE * 5 / 100)) \


### PR DESCRIPTION
NODE_PATH is not properly set without including the env variable on the command line. This causes a failure when using another layer to provide a node module, e.g. aws-sdk. NODE_PATH is set when using the official AWS Node Lambda runtime.