### PR TITLE
set AWS_EXECUTION_ENV

### DIFF
--- a/v10.x/bootstrap.js
+++ b/v10.x/bootstrap.js
@@ -15,6 +15,7 @@ const {
 } = process.env
 
 const [HOST, PORT] = AWS_LAMBDA_RUNTIME_API.split(':')
+process.env.AWS_EXECUTION_ENV = `AWS_Lambda_nodejs${process.versions.node}`
 
 start()
 

--- a/v11.x/bootstrap.js
+++ b/v11.x/bootstrap.js
@@ -15,6 +15,7 @@ const {
 } = process.env
 
 const [HOST, PORT] = AWS_LAMBDA_RUNTIME_API.split(':')
+process.env.AWS_EXECUTION_ENV = `AWS_Lambda_nodejs${process.versions.node}`
 
 start()
 


### PR DESCRIPTION
When running Amazon's node 8 runtime AWS_EXECUTION_ENV is set to AWS_Lambda_nodejs8.10

Modules like [is-lambda](https://npm.im/is-lambda) use this to detect a lambda environment.

This `PR` addes this environment variable using the running version of node from `process.versions.node`