### PR TITLE
Updated NODE_MAJOR to 12 for v12.x

### DIFF
--- a/v12.x/bootstrap.c
+++ b/v12.x/bootstrap.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 
 #ifndef NODE_MAJOR
-#define NODE_MAJOR "10"
+#define NODE_MAJOR "12"
 #endif
 
 #define AWS_EXECUTION_ENV "AWS_Lambda_nodejs" NODE_MAJOR "_lambci"


### PR DESCRIPTION
NODE_MAJOR was conspicuously `10` in the v12.x bootstrap.c file. I'm not sure if that was intentional, but figured I'd submit a PR for it anyway. Tests appear to run fine (`./test.sh` from the v12.x directory).