### PR TITLE
Added v12.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ Then save your lambda and test it with a test event!
 | Node.js version | ARN |
 | --- | --- |
 | 10.15.3 | `arn:aws:lambda:<region>:553035198032:layer:nodejs10:12` |
-| 12.0.0  | `arn:aws:lambda:<region>:553035198032:layer:nodejs12:1` |
+| 12.1.0  | `arn:aws:lambda:<region>:553035198032:layer:nodejs12:2` |
 
 ## Previous Version ARNs
 
 | Node.js version | ARN |
 | --- | --- |
+| 12.0.0  | `arn:aws:lambda:<region>:553035198032:layer:nodejs12:1` |
 | 11.14.0 | `arn:aws:lambda:<region>:553035198032:layer:nodejs11:17` |
 | 11.13.0 | `arn:aws:lambda:<region>:553035198032:layer:nodejs11:16` |
 | 11.12.0 | `arn:aws:lambda:<region>:553035198032:layer:nodejs11:13` |

--- a/v12.x/build.sh
+++ b/v12.x/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export NODE_VERSION=12.0.0
+export NODE_VERSION=12.1.0
 
 docker build --build-arg NODE_VERSION -t node-provided-lambda-v12.x .
 docker run --rm node-provided-lambda-v12.x cat /tmp/node-v${NODE_VERSION}.zip > ./layer.zip

--- a/v12.x/publish.sh
+++ b/v12.x/publish.sh
@@ -2,7 +2,7 @@
 
 LAYER_NAME=nodejs12
 
-NODE_VERSION=12.0.0
+NODE_VERSION=12.1.0
 
 REGIONS="$(aws ssm get-parameters-by-path --path /aws/service/global-infrastructure/services/lambda/regions \
   --query 'Parameters[].Value' --output text | tr '[:blank:]' '\n' | grep -v -e ^cn- -e ^us-gov- | sort -r)"


### PR DESCRIPTION
Added the current "stable" Node.js release - v12.1.0.

https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.1.0